### PR TITLE
media: exynos: mfc: Do not change clocks if a DRM context is running

### DIFF
--- a/drivers/media/platform/exynos/mfc/s5p_mfc_ctrl.c
+++ b/drivers/media/platform/exynos/mfc/s5p_mfc_ctrl.c
@@ -455,10 +455,8 @@ int mfc_init_hw(struct s5p_mfc_dev *dev, enum mfc_buf_usage_type buf_type)
 			s5p_mfc_clock_off(dev);
 			dev->curr_ctx_drm = curr_ctx_backup;
 			s5p_mfc_clock_on_with_base(dev, MFCBUF_NORMAL);
-		} else if (buf_type == MFCBUF_NORMAL) {
-			s5p_mfc_clock_off(dev);
-			dev->curr_ctx_drm = 1;
-			s5p_mfc_clock_on_with_base(dev, MFCBUF_DRM);
+		} else if (buf_type == MFCBUF_NORMAL && curr_ctx_backup) {
+			s5p_mfc_init_memctrl(dev, MFCBUF_DRM);
 		}
 	}
 #endif


### PR DESCRIPTION
I have no idea how Samsung works around this in userspace
in their Marshmallow libraries.
However, the new code (just turning the clocks off/on) causes
a sysmmu write page fault with out current BSP.

It looks like the new method (s5p_mfc_clock_on_with_base)
should handle the DRAM address change, but it doesn't.

Stack trace (with the new code):

<6>[  148.665003] [c7] [d:0, c:0] s5p_mfc_open:2132: NORMAL instance is opened [0:1]
<6>[  148.669014] [c4] [d:0] s5p_mfc_init_memctrl:302: [1] Base Address : 10000000
<6>[  148.669338] [c4] [d:0] mfc_init_hw:434: MFC v8.0, F/W: 15yy, 11mm, 13dd (E)
<6>[  148.669436] [c4] [d:0] s5p_mfc_init_memctrl:302: [2] Base Address : d0200000
<6>[  148.669485] [c4] [d:0, c:0] s5p_mfc_open:2236: MFC open completed [0:1] dev = e607d810, ctx = e2c28800
<6>[  148.669604] [c4] [d:0, c:0] s5p_mfc_release:2326: MFC driver release is called [0:1], is_drm(0)
<6>[  148.669814] [c4] [d:0] s5p_mfc_release:2544: mfc driver release finished [0:0], dev = e607d810
<6>[  148.683441] [c7] [d:0, c:0] s5p_mfc_open:2132: NORMAL instance is opened [0:1]
<6>[  148.691471] [c7] [d:0] s5p_mfc_init_memctrl:302: [1] Base Address : 10000000
<6>[  148.692177] [c7] [d:0] mfc_init_hw:434: MFC v8.0, F/W: 15yy, 11mm, 13dd (E)
<6>[  148.692402] [c7] [d:0] s5p_mfc_init_memctrl:302: [2] Base Address : d0200000
<6>[  148.692455] [c7] [d:0, c:0] s5p_mfc_open:2236: MFC open completed [0:1] dev = e607d810, ctx = e2c29000
<6>[  148.698577] [c0] [d:0, c:0] vidioc_s_fmt_vid_out_mplane:1403: Dec input codec(0): H264 Encoded Stream
<2>[  148.698908] [c0] ----------------------------------------------------------
<2>[  148.698947] [c0] 15200000.sysmmu WRITE PAGE FAULT at 0xd02febd0 by 152e0000.mfc0 (page table @ 0x455c0000)
<2>[  148.698974] [c0] AxID: 0xe, AxLEN: 0x0
<2>[  148.698997] [c0] Lv1 entry: 0x046063c1
<2>[  148.699020] [c0] ---------- System MMU Status -----------------------------
<2>[  148.699054] [c0] ADDR: 0x15200000(VA: 0xe7aa4000), MMU_CTRL: 0x00000005, PT_BASE: 0x000455c0
<2>[  148.699084] [c0] VERSION 5.0, MMU_CFG: 0x01100000, MMU_STATUS: 0x00000001
<2>[  148.699107] [c0] Level 2 TLB: on

...

Change-Id: I6223ac3a95fa3f8ccd18672de20a8ebc65ad248c