### PR TITLE
input: hall: Invert flip cover condition

### DIFF
--- a/drivers/input/hall.c
+++ b/drivers/input/hall.c
@@ -165,7 +165,7 @@ static void flip_cover_work(struct work_struct *work)
 
 	if(first == second) {
 		flip_cover = first;
-		input_report_switch(ddata->input, SW_FLIP, flip_cover);
+		input_report_switch(ddata->input, SW_LID, !flip_cover);
 		input_sync(ddata->input);
 	}
 }
@@ -198,7 +198,7 @@ static void flip_cover_work(struct work_struct *work)
 #endif
 	flip_cover = first;
 	input_report_switch(ddata->input,
-			SW_FLIP, flip_cover);
+			SW_LID, !flip_cover);
 	input_sync(ddata->input);
 }
 #endif
@@ -370,7 +370,7 @@ static int hall_probe(struct platform_device *pdev)
 	input->dev.parent = &pdev->dev;
 
 	input->evbit[0] |= BIT_MASK(EV_SW);
-	input_set_capability(input, EV_SW, SW_FLIP);
+	input_set_capability(input, EV_SW, SW_LID);
 
 	input->open = hall_open;
 	input->close = hall_close;


### PR DESCRIPTION
AOSP expects SW_LID instead of SW_FLIP.

Change-Id: I3c5b6211814f4575bc1c5eea257ba99a078dd6ad