### PR TITLE
battery: be more AOSP-friendly

### DIFF
--- a/drivers/battery/max77843_charger.c
+++ b/drivers/battery/max77843_charger.c
@@ -926,10 +926,12 @@ static int max77843_chg_get_property(struct power_supply *psy,
 		val->intval = max77843_get_charging_health(charger);
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
-		val->intval = charger->charging_current_max;
+		//AOSP expects the charging current to be in microamperes frameworks/base/core/java/android/os/BatteryManager.java L256
+		val->intval = charger->charging_current_max * 1000;
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_AVG:
-		val->intval = max77843_get_input_current(charger);
+		//AOSP expects the charging current to be in microamperes frameworks/base/core/java/android/os/BatteryManager.java L263
+		val->intval = max77843_get_input_current(charger) * 1000;
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_NOW:
 		val->intval = max77843_get_input_current(charger);


### PR DESCRIPTION
Change-Id: I3689e3d53b2d2cd4cdbb618c87db95850b368daa